### PR TITLE
Fix nphysics home & docs links

### DIFF
--- a/categories/physics.html
+++ b/categories/physics.html
@@ -208,13 +208,13 @@
                     <a href="https://github.com/sebcrozet/nphysics" title="github">
                       <i class="right floated github icon"></i>
                     </a>
-                    <a href="http://nphysics-dev.org/doc/nphysics" title="docs">
+                    <a href="http://nphysics.org/doc/nphysics3d/" title="docs">
                       <i class="right floated book icon"></i>
                     </a>
                     <a href="https://crates.io/crates/nphysics" title="crate">
                       <i class="right floated cube icon"></i>
                     </a>
-                    <a href="http://nphysics-dev.org/" title="home">
+                    <a href="http://nphysics.org/" title="home">
                       <i class="right floated home icon"></i>
                     </a>
                     <div class="header">nphysics</div>


### PR DESCRIPTION
Closes #58 

Note that I'm not sure about doc link: there're separate docs for 2d and 3d.