### PR TITLE
Fix Amethyst's logo URL

### DIFF
--- a/categories/engines.html
+++ b/categories/engines.html
@@ -273,7 +273,7 @@
                     <div class="header">amethyst</div>
                     <div class="description">
                       <p>Data-oriented game engine written in Rust</p>
-                      <img src="http://tinyurl.com/jtmm43a" class="ui image small floated right">
+                      <img src="https://tinyurl.com/ycljbplu" class="ui image small floated right">
                     </div>
                   </div>
                   <div class="extra content">


### PR DESCRIPTION
We moved the folder in which was stored the Amethyst logo.
This PR fixes the URL so that it points to the right image.