### PR TITLE
Update link to cgmath crate.

### DIFF
--- a/categories/math.html
+++ b/categories/math.html
@@ -211,7 +211,7 @@
                     <a href="http://brendanzab.github.io/cgmath" title="docs">
                       <i class="right floated book icon"></i>
                     </a>
-                    <a href="https://crates.io/crates/conrod" title="crate">
+                    <a href="https://crates.io/crates/cgmath" title="crate">
                       <i class="right floated cube icon"></i>
                     </a>
                     <a href="https://github.com/brendanzab/cgmath" title="home">


### PR DESCRIPTION
Crate link was pointing at conrod, should go to the cgmath crate.