### PR TITLE
Added ECS crates: nitric, froggy, pyro

### DIFF
--- a/content/categories/ecs/data.toml
+++ b/content/categories/ecs/data.toml
@@ -34,3 +34,15 @@ source = "crates"
 [[crates]]
 name = "calx-ecs"
 source = "crates"
+
+[[crates]]
+name = "nitric"
+source = "crates"
+
+[[crates]]
+name = "froggy"
+source = "crates"
+
+[[crates]]
+name = "pyro"
+source = "crates"


### PR DESCRIPTION
Froggy is a "Component Graph System", but it fits best into this category. Maybe the ECS category should be renamed "Data-processing"?