### PR TITLE
Fix menu links

### DIFF
--- a/templates/categories/page.html
+++ b/templates/categories/page.html
@@ -111,13 +111,13 @@ a taxonomy, which isn't completely accurate since it's more like pages with exte
         <i class="sidebar icon"></i>
       </a>
       <a class="active item" href="/">Home</a>
-      <a class="item" href="/index.html#chat">Chat</a>
-      <a class="item" href="/index.html#eco">Ecosystem</a>
-      <a class="item" href="/index.html#games">Games</a>
-      <a class="item" href="/index.html#curators">Curators</a>
-      <a class="item" href="/index.html#about">About</a>
+      <a class="item" href="/#chat">Chat</a>
+      <a class="item" href="/#eco">Ecosystem</a>
+      <a class="item" href="/#games">Games</a>
+      <a class="item" href="/#curators">Curators</a>
+      <a class="item" href="/#about">About</a>
       <div class="right item">
-        <a class="ui inverted button" href="/index.html#res">Resources</a>
+        <a class="ui inverted button" href="/#res">Resources</a>
         <a class="ui inverted button" href="https://github.com/doppioslash/arewegameyet">Contribute</a>
       </div>
     </div>

--- a/templates/categories/page.html
+++ b/templates/categories/page.html
@@ -111,13 +111,13 @@ a taxonomy, which isn't completely accurate since it's more like pages with exte
         <i class="sidebar icon"></i>
       </a>
       <a class="active item" href="/">Home</a>
-      <a class="item" href="../index.html#chat">Chat</a>
-      <a class="item" href="../index.html#eco">Ecosystem</a>
-      <a class="item" href="../index.html#games">Games</a>
-      <a class="item" href="../index.html#curators">Curators</a>
-      <a class="item" href="../index.html#about">About</a>
+      <a class="item" href="/index.html#chat">Chat</a>
+      <a class="item" href="/index.html#eco">Ecosystem</a>
+      <a class="item" href="/index.html#games">Games</a>
+      <a class="item" href="/index.html#curators">Curators</a>
+      <a class="item" href="/index.html#about">About</a>
       <div class="right item">
-        <a class="ui inverted button" href="../index.html#res">Resources</a>
+        <a class="ui inverted button" href="/index.html#res">Resources</a>
         <a class="ui inverted button" href="https://github.com/doppioslash/arewegameyet">Contribute</a>
       </div>
     </div>


### PR DESCRIPTION
While browsing the site I came across some broken links in the menu bar.

To reproduce this:
- Go to http://arewegameyet.com/#eco
- Click on any category (e.g. `2D Rendering`)
- From the category page, click on a menu item (e.g. `Chat`)

This fix was tested with `zola 0.5.1`