### PR TITLE
Add mod_player crate

### DIFF
--- a/content/categories/audio/data.toml
+++ b/content/categories/audio/data.toml
@@ -53,3 +53,8 @@ source = "crates"
 [[crates]]
 name = "gme"
 source = "crates"
+
+[[crates]]
+name = "mod_player"
+source = "crates"
+


### PR DESCRIPTION
A pure rust implementation of a mod audio player