### PR TITLE
add blend to 3d format loaders

### DIFF
--- a/content/categories/3dformatloaders/data.toml
+++ b/content/categories/3dformatloaders/data.toml
@@ -29,3 +29,7 @@ source = "crates"
 [[crates]]
 name = "fbxcel-dom"
 source = "crates"
+
+[[crates]]
+name = "blend"
+source = "crates"


### PR DESCRIPTION
Hi, this PR adds the crate [blend](https://crates.io/crates/blend) to the 3D format loaders.